### PR TITLE
Update netbox EE collections

### DIFF
--- a/network-netbox-eda-ee/ansible-collections.yml
+++ b/network-netbox-eda-ee/ansible-collections.yml
@@ -3,7 +3,7 @@ collections:
 
 ## certified or galaxy netbox
   - name: netbox.netbox
-    version: 3.21.0
+    version: 3.22.0
 
 ## community collections
   - name: community.general
@@ -12,49 +12,29 @@ collections:
 ## validated collections
 
 
-## certified collections
+## ansible collections
   - name: ansible.netcommon               
-#    version: 7.1.0
   - name: ansible.network                 
-#    version: 4.0.0
   - name: ansible.posix                   
-#    version: 1.5.4
-  - name: ansible.scm                     
-#    version: 3.0.0
+#  - name: ansible.scm                     
 #  - name: ansible.security                
-#    version: 3.0.0
-  - name: ansible.snmp                    
-#    version: 3.0.0
+#  - name: ansible.snmp                    
   - name: ansible.utils                   
-#    version: 5.1.2
   - name: ansible.yang                    
-#    version: 3.0.0
-  - name: arista.eos                      
-#    version: 10.0.0
-  - name: cisco.ios
-#    version: 9.0.2
-  - name: junipernetworks.junos
-#    version: 9.1.0
 
-## disabled collections, due to conflict or unneeded
+## network vendors
+  - name: arista.eos                      
+  - name: cisco.ios
+  - name: junipernetworks.junos
+#  - name: cisco.nxos                      
+#  - name: cisco.dnac
+#  - name: cisco.meraki
+#  - name: servicenow.itsm                 
+#  - name: cisco.asa                       
+#  - name: cisco.iosxr                     
+
 ## alt netbox source for devel branch
 #  - name: https://github.com/netbox-community/ansible_modules.git
 #    version: devel
 #    type: git
-#  - name: ansible.controller              
-#    version: ">=4.6.1"
-#  - name: ansible.eda                     
-#    version: ">=2.1.0"
-#  - name: cisco.nxos                      
-#    version: 9.2.1
-#  - name: cisco.dnac
-#  - name: cisco.meraki
-#  - name: redhat.rhel_system_roles
-#    version: 1.21.1
-#  - name: servicenow.itsm                 
-#    version: 2.6.3
-#  - name: cisco.asa                       
-#    version: 6.0.0
-#  - name: cisco.iosxr                     
-#    version: 10.1.0
 


### PR DESCRIPTION
Bump netbox.netbox to 3.22.0, remove unused version pins, comment out ansible.scm and ansible.snmp, reorganize collection sections.