### PR TITLE
Unpin ansible-builder from 3.0.0

### DIFF
--- a/network-ee/requirements.txt
+++ b/network-ee/requirements.txt
@@ -1,4 +1,5 @@
 # Extra Python packages not already satisfied by ee-supported-rhel9 base image.
+# ovirt-engine-sdk-python is source-only — requires setuptools to compile.
 # Most network collection deps (ncclient, paramiko, textfsm, ttp, jxmlease,
 # xmltodict, netaddr, scp, etc.) are pre-installed via the base image's
 # bundled collections. Only add packages the DELTA collections need or

--- a/network-netbox-eda-ee/ansible-collections.yml
+++ b/network-netbox-eda-ee/ansible-collections.yml
@@ -16,7 +16,7 @@ collections:
   - name: ansible.netcommon               
   - name: ansible.network                 
   - name: ansible.posix                   
-#  - name: ansible.scm                     
+  - name: ansible.scm
 #  - name: ansible.security                
 #  - name: ansible.snmp                    
   - name: ansible.utils                   

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-builder==3.0.0
+ansible-builder


### PR DESCRIPTION
Remove the `ansible-builder==3.0.0` pin from `requirements.txt`.

The pin was added when `network-ee` needed the `exclude` directive (builder 3.1+) but had `pip install --upgrade pip` in its `prepend_base`, which upgraded pip to 26 and broke build isolation for source-only packages. The root cause was the pip upgrade in the EE definition, not the builder version.

The current `network-ee` no longer upgrades pip in `prepend_base`, so unpinning the builder is safe and gives access to 3.1+ features like `dependencies.exclude`.